### PR TITLE
main page: fix dulplicated account badge

### DIFF
--- a/lib/pages/accounts_page.dart
+++ b/lib/pages/accounts_page.dart
@@ -70,6 +70,7 @@ class AccountsPage extends StatelessWidget {
               ),
             );
             element.saveData();
+            ComicSource.notifyListeners();
             logic.update();
           },
         );
@@ -124,6 +125,7 @@ class AccountsPage extends StatelessWidget {
             element.data["account"] = null;
             element.account?.logout();
             element.saveData();
+            ComicSource.notifyListeners();
             logic.update();
           },
           trailing: const Icon(Icons.logout),

--- a/lib/pages/comic_source_page.dart
+++ b/lib/pages/comic_source_page.dart
@@ -40,6 +40,7 @@ class ComicSourcePage extends StatefulWidget {
     }
     controller?.close();
     if (shouldUpdate.isEmpty) {
+      App.rootContext.showMessage(message: "No Update Available".tl);
       return;
     }
     var msg = "";

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -820,6 +820,7 @@ class _AccountsWidgetState extends State<_AccountsWidget> {
 
   void onComicSourceChange() {
     setState(() {
+      accounts.clear();
       for (var c in ComicSource.all()) {
         if (c.isLogged) {
           accounts.add(c.name);


### PR DESCRIPTION
更新漫画源 导致首页刷新前显示重复的账号信息。
![image](https://github.com/user-attachments/assets/f0b135f8-9c44-4881-b81d-2018e5c8ca61)
