### PR TITLE
fix: ReaderScaffold Bottom not fully hidden on iOS

### DIFF
--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -147,7 +147,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
         ),
         AnimatedPositioned(
           duration: const Duration(milliseconds: 180),
-          bottom: _isOpen ? 0 : -kBottomBarHeight,
+          bottom: _isOpen ? 0 : -(kBottomBarHeight + MediaQuery.of(context).padding.bottom),
           left: 0,
           right: 0,
           child: buildBottom(),


### PR DESCRIPTION
fix #7 