### PR TITLE
Experimental Support for Setting New Storage Path on iOS

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		C0086D072CDEFE6E004596D9 /* DirectoryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0086D062CDEFE64004596D9 /* DirectoryPicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C0086D062CDEFE64004596D9 /* DirectoryPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryPicker.swift; sourceTree = "<group>"; };
 		C22B8A9F3177D4A68EB8F66B /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -133,6 +135,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				C0086D062CDEFE64004596D9 /* DirectoryPicker.swift */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -144,7 +147,6 @@
 				730F73FE38E23FCF3E461640 /* Pods-Runner.release.xcconfig */,
 				29B89F848F26E839605E1D88 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -336,6 +338,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0086D072CDEFE6E004596D9 /* DirectoryPicker.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,11 +1,15 @@
 import Flutter
 import UIKit
 import UniformTypeIdentifiers
+import Foundation // 添加此行
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, UIDocumentPickerDelegate {
   var flutterResult: FlutterResult?
   var directoryPath: URL!
+
+  // 定义插件通道名称
+  private var directoryPicker: DirectoryPicker?
 
   override func application(
     _ application: UIApplication,
@@ -42,6 +46,9 @@ import UniformTypeIdentifiers
         self.directoryPath?.stopAccessingSecurityScopedResource()
         self.directoryPath = nil
         result(nil)
+      } else if call.method == "selectDirectory" {
+        self.directoryPicker = DirectoryPicker()
+        self.directoryPicker?.selectDirectory(result: result)
       } else {
         result(FlutterMethodNotImplemented)
       }

--- a/ios/Runner/DirectoryPicker.swift
+++ b/ios/Runner/DirectoryPicker.swift
@@ -1,0 +1,36 @@
+import UIKit
+import Flutter
+
+class DirectoryPicker: NSObject, UIDocumentPickerDelegate {
+    private var result: FlutterResult?
+
+    // 初始化选择目录方法
+    func selectDirectory(result: @escaping FlutterResult) {
+        self.result = result
+
+        // 配置 UIDocumentPicker 为目录选择模式
+        let documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: [.folder])
+        documentPicker.delegate = self
+        documentPicker.allowsMultipleSelection = false
+
+        // 获取根视图控制器并显示选择器
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
+            rootViewController.present(documentPicker, animated: true, completion: nil)
+        }
+    }
+
+    // 处理选择完成后的结果
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        // 获取选中的路径
+        if let url = urls.first {
+            result?(url.path)
+        } else {
+            result?(nil)
+        }
+    }
+
+    // 处理取消选择情况
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        result?(nil)
+    }
+}

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,6 +46,10 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
-  <string>Choose images</string>
+  	<string>Choose images</string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/pages/settings/app.dart
+++ b/lib/pages/settings/app.dart
@@ -32,11 +32,16 @@ class _AppSettingsState extends State<AppSettings> {
           title: "Set New Storage Path".tl,
           actionTitle: "Set".tl,
           callback: () async {
-            if (App.isMobile) {
+            var result;
+            if (App.isAndroid) {
               context.showMessage(message: "Not supported".tl);
               return;
             }
-            var result = await selectDirectory();
+            else if (App.isIOS) {
+              result = await selectDirectoryIOS();
+            } else {
+              result = await selectDirectory();
+            }
             if (result == null) return;
             var loadingDialog = showLoadingDialog(
               App.rootContext,

--- a/lib/pages/settings/app.dart
+++ b/lib/pages/settings/app.dart
@@ -20,6 +20,13 @@ class _AppSettingsState extends State<AppSettings> {
         ListTile(
           title: Text("Storage Path for local comics".tl),
           subtitle: Text(LocalManager().path, softWrap: false),
+          trailing: IconButton(
+            icon: const Icon(Icons.copy),
+            onPressed: () {
+              Clipboard.setData(ClipboardData(text: LocalManager().path));
+              context.showMessage(message: "Path copied to clipboard".tl);
+            },
+          ),
         ).toSliver(),
         _CallbackSetting(
           title: "Set New Storage Path".tl,

--- a/lib/utils/io.dart
+++ b/lib/utils/io.dart
@@ -160,6 +160,22 @@ class DirectoryPicker {
   }
 }
 
+class IOSDirectoryPicker {
+  static const MethodChannel _channel = MethodChannel("venera/method_channel");
+
+  // 调用 iOS 目录选择方法
+  static Future<String?> selectDirectory() async {
+    try {
+      final String? path = await _channel.invokeMethod('selectDirectory');
+      return path;
+    } catch (e) {
+      print("Error selecting directory: $e");
+      // 返回报错信息
+      return e.toString();
+    }
+  }
+}
+
 Future<file_selector.XFile?> selectFile({required List<String> ext}) async {
   file_selector.XTypeGroup typeGroup = file_selector.XTypeGroup(
     label: 'files',
@@ -179,6 +195,11 @@ Future<file_selector.XFile?> selectFile({required List<String> ext}) async {
 Future<String?> selectDirectory() async {
   var path = await file_selector.getDirectoryPath();
   return path;
+}
+
+// selectDirectoryIOS
+Future<String?> selectDirectoryIOS() async {
+  return IOSDirectoryPicker.selectDirectory();
 }
 
 Future<void> saveFile(


### PR DESCRIPTION
This pull request introduces the following changes:

1. Experimental support for setting a new storage path on iOS.
2. Added a "Copy Storage Path" button in the app settings page.
3. Experimental support for multi selection in local_comics_page.