### PR TITLE
EhViewer数据导入&本地下载选择优化

### DIFF
--- a/assets/translation.json
+++ b/assets/translation.json
@@ -141,7 +141,7 @@
     "1. The directory only contains image files." : "1. 目录只包含图片文件。",
     "2. The directory contains directories which contain image files. Each directory is considered as a chapter." : "2. 目录包含多个包含图片文件的目录。每个目录被视为一个章节。",
     "If the directory contains a file named 'cover.*', it will be used as the cover image. Otherwise the first image will be used." : "如果目录包含一个名为'cover.*'的文件，它将被用作封面图片。否则将使用第一张图片。",
-    "The directory name will be used as the comic title. And the name of chapter directories will be used as the chapter titles." : "目录名称将被用作漫画标题。章节目录的名称将被用作章节标题。",
+    "The directory name will be used as the comic title. And the name of chapter directories will be used as the chapter titles.\n" : "目录名称将被用作漫画标题。章节目录的名称将被用作章节标题。\n",
     "Export as cbz": "导出为cbz",
     "Select a cbz file." : "选择一个cbz文件",
     "A cbz file" : "一个cbz文件",
@@ -190,7 +190,18 @@
     "Long press on the favorite button to quickly add to this folder": "长按收藏按钮快速添加到这个文件夹",
     "Added": "已添加",
     "Turn page by volume keys": "使用音量键翻页",
-    "Display time & battery info in reader":"在阅读器中显示时间和电量信息"
+    "Display time & battery info in reader":"在阅读器中显示时间和电量信息",
+    "EhViewer downloads":"EhViewer下载",
+    "Select an EhViewer database and a download folder.":"选择EhViewer的下载数据（导出的db文件）与存放下载内容的目录",
+    "(EhViewer)Default": "(EhViewer)默认",
+    "If you import an EhViewer's database, program will automatically create folders according to the download label in that database.": "若通过EhViewer数据库导入漫画，程序将会按其中的下载标签自动创建收藏文件夹。",
+    "Multi-Select": "进入多选模式",
+    "Exit Multi-Select": "退出多选模式",
+    "Selected @c comics": "已选择 @c 本漫画",
+    "Select All": "全选",
+    "Deselect": "取消选择",
+    "Invert Selection": "反选",
+    "Select in range": "区间选择"
   },
   "zh_TW": {
     "Home": "首頁",
@@ -334,7 +345,7 @@
     "1. The directory only contains image files." : "1. 目錄只包含圖片文件。",
     "2. The directory contains directories which contain image files. Each directory is considered as a chapter." : "2. 目錄包含多個包含圖片文件的目錄。每個目錄被視為一個章節。",
     "If the directory contains a file named 'cover.*', it will be used as the cover image. Otherwise the first image will be used." : "如果目錄包含一個名為'cover.*'的文件，它將被用作封面圖片。否則將使用第一張圖片。",
-    "The directory name will be used as the comic title. And the name of chapter directories will be used as the chapter titles." : "目錄名稱將被用作漫畫標題。章節目錄的名稱將被用作章節標題。",
+    "The directory name will be used as the comic title. And the name of chapter directories will be used as the chapter titles.\n" : "目錄名稱將被用作漫畫標題。章節目錄的名稱將被用作章節標題。\n",
     "Export as cbz": "匯出為cbz",
     "Select a cbz file." : "選擇一個cbz文件",
     "A cbz file" : "一個cbz文件",
@@ -383,6 +394,17 @@
     "Long press on the favorite button to quickly add to this folder": "長按收藏按鈕快速添加到這個文件夾",
     "Added": "已添加",
     "Turn page by volume keys": "使用音量鍵翻頁",
-    "Display time & battery info in reader":"在閱讀器中顯示時間和電量信息"
+    "Display time & battery info in reader": "在閱讀器中顯示時間和電量信息",
+    "EhViewer downloads": "EhViewer下載",
+    "Select an EhViewer database and a download folder.": "選擇EhViewer的下載資料（匯出的db檔案）與存放下載內容的目錄",
+    "(EhViewer)Default": "(EhViewer)預設",
+    "If you import an EhViewer's database, program will automatically create folders according to the download label in that database.": "若透過EhViewer資料庫匯入漫畫，程式將會按其中的下載標籤自動建立收藏資料夾。",
+    "Multi-Select": "進入多選模式",
+    "Exit Multi-Select": "退出多選模式",
+    "Selected @c comics": "已選擇 @c 本漫畫",
+    "Select All": "全選",
+    "Deselect": "取消選擇",
+    "Invert Selection": "反選",
+    "Select in range": "區間選擇"
   }
 }

--- a/lib/components/comic.dart
+++ b/lib/components/comic.dart
@@ -581,9 +581,12 @@ class SliverGridComics extends StatefulWidget {
     this.badgeBuilder,
     this.menuBuilder,
     this.onTap,
+    this.selections
   });
 
   final List<Comic> comics;
+
+  final Map<Comic, bool>? selections;
 
   final void Function()? onLastItemBuild;
 
@@ -638,6 +641,7 @@ class _SliverGridComicsState extends State<SliverGridComics> {
   Widget build(BuildContext context) {
     return _SliverGridComics(
       comics: comics,
+      selection: widget.selections,
       onLastItemBuild: widget.onLastItemBuild,
       badgeBuilder: widget.badgeBuilder,
       menuBuilder: widget.menuBuilder,
@@ -653,9 +657,12 @@ class _SliverGridComics extends StatelessWidget {
     this.badgeBuilder,
     this.menuBuilder,
     this.onTap,
+    this.selection,
   });
 
   final List<Comic> comics;
+
+  final Map<Comic, bool>? selection;
 
   final void Function()? onLastItemBuild;
 
@@ -674,11 +681,37 @@ class _SliverGridComics extends StatelessWidget {
             onLastItemBuild?.call();
           }
           var badge = badgeBuilder?.call(comics[index]);
-          return ComicTile(
-            comic: comics[index],
-            badge: badge,
-            menuOptions: menuBuilder?.call(comics[index]),
-            onTap: onTap != null ? () => onTap!(comics[index]) : null,
+          return Stack(
+            children: [
+              ComicTile(
+                comic: comics[index],
+                badge: badge,
+                menuOptions: menuBuilder?.call(comics[index]),
+                onTap: onTap != null ? () => onTap!(comics[index]) : null,
+              ),
+              Positioned(
+                bottom: 10,
+                right: 8,
+                child: Visibility(
+                  visible: selection == null ? false : selection![comics[index]] ?? false,
+                  child: Stack(
+                    children: [
+                      Transform.scale(
+                        scale: 0.9,
+                        child: const Icon(
+                          Icons.circle_rounded,
+                          color: Colors.white,
+                        )
+                      ),
+                      const Icon(
+                        Icons.check_circle_rounded,
+                        color: Colors.green,
+                      )
+                    ],
+                  )
+                )
+              )
+            ],
           );
         },
         childCount: comics.length,

--- a/lib/foundation/local.dart
+++ b/lib/foundation/local.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:venera/foundation/comic_source/comic_source.dart';
 import 'package:venera/foundation/comic_type.dart';
+import 'package:venera/foundation/favorites.dart';
 import 'package:venera/foundation/log.dart';
 import 'package:venera/network/download.dart';
 import 'package:venera/pages/reader/reader.dart';
@@ -346,6 +347,10 @@ class LocalManager with ChangeNotifier {
             comic.cover) {
           continue;
         }
+        //Hidden file in some file system
+        if(entity.name.startsWith('.')) {
+          continue;
+        }
         files.add(entity);
       }
     }
@@ -439,9 +444,20 @@ class LocalManager with ChangeNotifier {
     downloadingTasks.first.resume();
   }
 
-  void deleteComic(LocalComic c) {
-    var dir = Directory(FilePath.join(path, c.directory));
-    dir.deleteIgnoreError(recursive: true);
+  void deleteComic(LocalComic c, [bool removeFileOnDisk = true]) {
+    if(removeFileOnDisk) {
+      var dir = Directory(FilePath.join(path, c.directory));
+      dir.deleteIgnoreError(recursive: true);
+    }
+    //Deleting a local comic means that it's nolonger available, thus both favorite and history should be deleted.
+    if(HistoryManager().findSync(c.id, c.comicType) != null) {
+      HistoryManager().remove(c.id, c.comicType);
+    }
+    assert(c.comicType == ComicType.local);
+    var folders = LocalFavoritesManager().find(c.id, c.comicType);
+    for (var f in folders) {
+      LocalFavoritesManager().deleteComicWithId(f, c.id, c.comicType);
+    }
     remove(c.id, c.comicType);
     notifyListeners();
   }

--- a/lib/pages/favorites/local_favorites_page.dart
+++ b/lib/pages/favorites/local_favorites_page.dart
@@ -207,7 +207,7 @@ class _ReorderComicsPageState extends State<_ReorderComicsPage> {
             e.author,
             e.tags,
             "${e.time} | ${comicSource?.name ?? "Unknown"}",
-            comicSource?.key ?? "Unknown",
+            comicSource?.key ?? (e.type == ComicType.local ?  "local" : "Unknown"),
             null,
             null,
           ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -640,7 +640,9 @@ class _ImportComicsWidgetState extends State<_ImportComicsWidget> {
       if (dbFile == null || comicSrc == null) {
         return;
       }
-      var controller = showLoadingDialog(context, allowCancel: false);
+
+      bool cancelled = false;
+      var controller = showLoadingDialog(context, onCancel: () { cancelled = true; });
 
       try {
         var cache = FilePath.join(App.cachePath, dbFile.name);
@@ -649,6 +651,9 @@ class _ImportComicsWidgetState extends State<_ImportComicsWidget> {
 
         Future<void> addTagComics(String destFolder, List<sql.Row> comics) async {
           for(var comic in comics) {
+            if(cancelled) {
+              return;
+            }
             var comicDir = Directory(FilePath.join(comicSrc.path, comic['DIRNAME'] as String));
             if(!(await comicDir.exists())) {
               continue;
@@ -731,6 +736,9 @@ class _ImportComicsWidgetState extends State<_ImportComicsWidget> {
           """);
 
         for (var folder in folders) {
+          if(cancelled) {
+            break;
+          }
           var label = folder["LABEL"] as String;
           var folderName = '(EhViewer)$label';
           if(!LocalFavoritesManager().existsFolder(folderName)) {

--- a/lib/pages/local_comics_page.dart
+++ b/lib/pages/local_comics_page.dart
@@ -116,6 +116,106 @@ class _LocalComicsPageState extends State<LocalComicsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double screenWidth = MediaQuery.of(context).size.width;
+    final bool isScreenSmall = screenWidth < 500.0;
+
+    void selectAll(){
+      setState(() {
+        selectedComics = comics.asMap().map((k, v) => MapEntry(v, true));
+      });
+    }
+    void deSelect() {
+      setState(() {
+        selectedComics.clear();
+      });
+    }
+    void invertSelection() {
+      setState(() {
+        comics.asMap().forEach((k, v) {
+          selectedComics[v] = !selectedComics.putIfAbsent(v, () => false);
+        });
+        selectedComics.removeWhere((k, v) => !v);
+      });
+    }
+    void selectRange() {
+      setState(() {
+        List<int> l = [];
+        selectedComics.forEach((k, v) {
+          l.add(comics.indexOf(k as LocalComic));
+        });
+        if(l.isEmpty) {
+          return;
+        }
+        l.sort();
+        int start = l.first;
+        int end = l.last;
+        selectedComics.clear();
+        selectedComics.addEntries(
+          List.generate(end - start + 1, (i) {
+            return MapEntry(comics[start + i], true);
+          })
+        );
+      });
+    }
+
+    List<Widget> selectActions = [];
+    if(isScreenSmall) {
+      selectActions.add(
+        IconButton(
+          onPressed: () {
+            showMenu(
+              context: context, 
+              position: RelativeRect.fromLTRB(screenWidth, App.isMobile ? 64 : 96, 0, 0),
+              items: <PopupMenuEntry>[
+                PopupMenuItem(
+                  onTap: selectAll,
+                  child: Text("Select All".tl),
+                ),
+                PopupMenuItem(
+                  onTap: deSelect,
+                  child: Text("Deselect".tl),
+                ),
+                PopupMenuItem(
+                  onTap: invertSelection,
+                  child: Text("Invert Selection".tl),
+                ),
+                PopupMenuItem(
+                  onTap: selectRange,
+                  child: Text("Select in range".tl),
+                )
+              ]
+            );
+          }, 
+          icon: const Icon(
+          Icons.list
+        ))
+      );
+    }else {
+      selectActions = [
+        IconButton(
+          icon: const Icon(Icons.check_box_rounded),
+          tooltip: "Select All".tl,
+          onPressed: selectAll
+        ),
+        IconButton(
+          icon: const Icon(Icons.check_box_outline_blank_outlined),
+          tooltip: "Deselect".tl,
+          onPressed: deSelect
+        ),
+        IconButton(
+          icon: const Icon(Icons.check_box_outlined),
+          tooltip: "Invert Selection".tl,
+          onPressed: invertSelection
+        ),
+        
+        IconButton(
+          icon: const Icon(Icons.indeterminate_check_box_rounded),
+          tooltip: "Select in range".tl,
+          onPressed: selectRange
+        ),
+      ];
+    }
+
     return Scaffold(
       body: SmoothCustomScrollView(
         slivers: [
@@ -169,71 +269,17 @@ class _LocalComicsPageState extends State<LocalComicsPage> {
             SliverAppbar(
               title: Text("Selected @c comics".tlParams({"c": selectedComics.length})),
               actions: [
-                IconButton(
-                  icon: const Icon(Icons.check_box_rounded),
-                  tooltip: "Select All".tl,
-                  onPressed: () {
-                    setState(() {
-                      selectedComics = comics.asMap().map((k, v) => MapEntry(v, true));
-                    });
-                  },
-                ),
-                IconButton(
-                  icon: const Icon(Icons.check_box_outline_blank_outlined),
-                  tooltip: "Deselect".tl,
-                  onPressed: () {
-                    setState(() {
-                      selectedComics.clear();
-                    });
-                  },
-                ),
-                IconButton(
-                  icon: const Icon(Icons.check_box_outlined),
-                  tooltip: "Invert Selection".tl,
-                  onPressed: () {
-                    setState(() {
-                      comics.asMap().forEach((k, v) {
-                        selectedComics[v] = !selectedComics.putIfAbsent(v, () => false);
+                  ...selectActions,
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    tooltip: "Exit Multi-Select".tl,
+                    onPressed: () {
+                      setState(() {
+                        multiSelectMode = false;
+                        selectedComics.clear();
                       });
-                      selectedComics.removeWhere((k, v) => !v);
-                    });
-                  },
-                ),
-                
-                IconButton(
-                  icon: const Icon(Icons.indeterminate_check_box_rounded),
-                  tooltip: "Select in range".tl,
-                  onPressed: () {
-                    setState(() {
-                      List<int> l = [];
-                      selectedComics.forEach((k, v) {
-                        l.add(comics.indexOf(k as LocalComic));
-                      });
-                      if(l.isEmpty) {
-                        return;
-                      }
-                      l.sort();
-                      int start = l.first;
-                      int end = l.last;
-                      selectedComics.clear();
-                      selectedComics.addEntries(
-                        List.generate(end - start + 1, (i) {
-                          return MapEntry(comics[start + i], true);
-                        })
-                      );
-                    });
-                  },
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close),
-                  tooltip: "Exit Multi-Select".tl,
-                  onPressed: () {
-                    setState(() {
-                      multiSelectMode = false;
-                      selectedComics.clear();
-                    });
-                  },
-                ),
+                    },
+                  ),
                 
               ],
             )

--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -650,7 +650,7 @@ class _BatteryWidgetState extends State<_BatteryWidget> {
 
   Widget _batteryInfo(int batteryLevel) {
     IconData batteryIcon;
-    Color batteryColor = Colors.black;
+    Color batteryColor = context.colorScheme.onSurface;
 
     if (batteryLevel >= 96) {
       batteryIcon = Icons.battery_full_sharp;


### PR DESCRIPTION
修复：电池图标颜色与主题颜色不匹配
修复：本地漫画封面显示逻辑，当comicSource为null时，将检查ComicType
改进：阅读器将忽略漫画文件夹中以'.'开头的文件（某些文件系统的隐藏文件）
新增：EhViewer下载内容导入功能
改进：允许创建收藏项目时提供收藏创建时间（主要为EhViewer导入功能服务）
改进：为本地漫画管理页面多选模式增加选中效果以及全选、反选、取消选择、区间选择功能
改进：添加翻译内容