### PR TITLE
export/import: use .venera.zip

### DIFF
--- a/lib/pages/settings/app.dart
+++ b/lib/pages/settings/app.dart
@@ -118,7 +118,7 @@ class _AppSettingsState extends State<AppSettings> {
           callback: () async {
             var controller = showLoadingDialog(context);
             var file = await exportAppData();
-            await saveFile(filename: "data.venera", file: file);
+            await saveFile(filename: "data.venera.zip", file: file);
             controller.close();
           },
           actionTitle: 'Export'.tl,
@@ -127,9 +127,9 @@ class _AppSettingsState extends State<AppSettings> {
           title: "Import App Data".tl,
           callback: () async {
             var controller = showLoadingDialog(context);
-            var file = await selectFile(ext: ['venera']);
+            var file = await selectFile(ext: ['zip']);
             if (file != null) {
-              var cacheFile = File(FilePath.join(App.cachePath, "temp.venera"));
+              var cacheFile = File(FilePath.join(App.cachePath, "temp.venera.zip"));
               await file.saveTo(cacheFile.path);
               try {
                 await importAppData(cacheFile);

--- a/lib/utils/data.dart
+++ b/lib/utils/data.dart
@@ -13,7 +13,7 @@ import 'io.dart';
 
 Future<File> exportAppData() async {
   var time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-  var cacheFilePath = FilePath.join(App.cachePath, '$time.venera');
+  var cacheFilePath = FilePath.join(App.cachePath, '$time.venera.zip');
   var cacheFile = File(cacheFilePath);
   var dataPath = App.dataPath;
   if (await cacheFile.exists()) {


### PR DESCRIPTION
AOSP File Picker 无法指定 .venera，MIME 判断为了 BIN，导致导入后扩展名校验失败。
`W/FileSelectorApiImpl( 5242): Extension not supported: venera`
`I/flutter ( 5242): /data/user/0/com.github.wgh136.venera/cache/ffffffff-ffff-ffff-ffff-ffffffffffff/1234567890.bin`