### PR TITLE
安卓端文件导入&收藏项目清理

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <application
         android:label="venera"
         android:name="${applicationName}"
+        android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/assets/translation.json
+++ b/assets/translation.json
@@ -210,7 +210,9 @@
     "Create Folder": "新建文件夹",
     "Select an image on screen": "选择屏幕上的图片",
     "Added @count comics to download queue.": "已添加 @count 本漫画到下载队列",
-    "Copy to app local path": "将漫画复制到本地存储目录中"
+    "Copy to app local path": "将漫画复制到本地存储目录中",
+    "Delete all unavailable local favorite items": "删除所有无效的本地收藏",
+    "Deleted @a favorite items.": "已删除 @a 条无效收藏"
   },
   "zh_TW": {
     "Home": "首頁",
@@ -423,6 +425,8 @@
     "Create Folder": "新建文件夾",
     "Select an image on screen": "選擇屏幕上的圖片",
     "Added @count comics to download queue.": "已添加 @count 本漫畫到下載隊列",
-    "Copy to app local path": "將漫畫複製到本地儲存目錄中"
+    "Copy to app local path": "將漫畫複製到本地儲存目錄中",
+    "Delete all unavailable local favorite items": "刪除所有無效的本地收藏",
+    "Deleted @a favorite items.": "已刪除 @a 條無效收藏"
   }
 }

--- a/assets/translation.json
+++ b/assets/translation.json
@@ -209,7 +209,8 @@
     "Update Comics Info": "更新漫画信息",
     "Create Folder": "新建文件夹",
     "Select an image on screen": "选择屏幕上的图片",
-    "Added @count comics to download queue.": "已添加 @count 本漫画到下载队列"
+    "Added @count comics to download queue.": "已添加 @count 本漫画到下载队列",
+    "Copy to app local path": "将漫画复制到本地存储目录中"
   },
   "zh_TW": {
     "Home": "首頁",
@@ -421,6 +422,7 @@
     "Update Comics Info": "更新漫畫信息",
     "Create Folder": "新建文件夾",
     "Select an image on screen": "選擇屏幕上的圖片",
-    "Added @count comics to download queue.": "已添加 @count 本漫畫到下載隊列"
+    "Added @count comics to download queue.": "已添加 @count 本漫畫到下載隊列",
+    "Copy to app local path": "將漫畫複製到本地儲存目錄中"
   }
 }

--- a/lib/foundation/favorites.dart
+++ b/lib/foundation/favorites.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:venera/foundation/appdata.dart';
 import 'package:venera/foundation/image_provider/local_favorite_image.dart';
+import 'package:venera/foundation/local.dart';
 import 'package:venera/foundation/log.dart';
 import 'dart:io';
 
@@ -430,6 +431,22 @@ class LocalFavoritesManager with ChangeNotifier {
       where id == ? and type == ?;
     """, [id, type.value]);
     notifyListeners();
+  }
+
+  Future<int> removeInvalid() async {
+    int count = 0;
+    await Future.microtask(() {
+      var all = allComics();
+      for(var c in all) {
+        var comicSource = c.type.comicSource;
+        if ((c.type == ComicType.local && LocalManager().find(c.id, c.type) == null) 
+          || (c.type != ComicType.local && comicSource == null)) {
+          deleteComicWithId(c.folder, c.id, c.type);
+          count++;
+        }
+      }
+    });
+    return count;
   }
 
   Future<void> clearAll() async {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -795,6 +795,7 @@ class _ImportComicsWidgetState extends State<_ImportComicsWidget> {
       }
     }
 
+    fileList.sort();
     coverPath = fileList.firstWhereOrNull((l) => l.startsWith('cover')) ?? fileList.first;
         
     chapters.sort();

--- a/lib/pages/settings/local_favorites.dart
+++ b/lib/pages/settings/local_favorites.dart
@@ -38,6 +38,16 @@ class _LocalFavoritesSettingsState extends State<LocalFavoritesSettings> {
             for (var e in LocalFavoritesManager().folderNames) e: e
           },
         ).toSliver(),
+        _CallbackSetting(
+          title: "Delete all unavailable local favorite items".tl,
+          callback: () async {
+            var controller = showLoadingDialog(context);
+            var count = await LocalFavoritesManager().removeInvalid();
+            controller.close();
+            context.showMessage(message: "Deleted @a favorite items".tlParams({'a': count}));
+          },
+          actionTitle: 'Delete'.tl,
+        ).toSliver(),
       ],
     );
   }

--- a/lib/utils/io.dart
+++ b/lib/utils/io.dart
@@ -8,6 +8,7 @@ import 'package:venera/foundation/app.dart';
 import 'package:venera/utils/ext.dart';
 import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart' as s;
+import 'package:file_picker/file_picker.dart' as file_picker;
 import 'package:file_selector/file_selector.dart' as file_selector;
 import 'package:venera/utils/file_type.dart';
 
@@ -152,13 +153,8 @@ class DirectoryPicker {
   final _methodChannel = const MethodChannel("venera/method_channel");
 
   Future<Directory?> pickDirectory() async {
-    if (App.isWindows || App.isLinux) {
-      var d = await file_selector.getDirectoryPath();
-      _directory = d;
-      return d == null ? null : Directory(d);
-    } else if (App.isAndroid) {
-      var d = await _methodChannel.invokeMethod<String?>("getDirectoryPath");
-      _directory = d;
+    if (App.isWindows || App.isLinux || App.isAndroid) {
+      var d = await file_picker.FilePicker.platform.getDirectoryPath();
       return d == null ? null : Directory(d);
     } else {
       // ios, macos
@@ -171,9 +167,6 @@ class DirectoryPicker {
   Future<void> dispose() async {
     if (_directory == null) {
       return;
-    }
-    if (App.isAndroid && _directory != null) {
-      return Directory(_directory!).deleteIgnoreError(recursive: true);
     }
     if (App.isIOS || App.isMacOS) {
       await _methodChannel.invokeMethod("stopAccessingSecurityScopedResource");

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -194,6 +194,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "16dc141db5a2ccc6520ebb6a2eb5945b1b09e95085c021d9f914f8ded7f1465c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.4"
   file_selector:
     dependency: "direct main"
     description:
@@ -356,6 +364,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "9b78450b89f059e96c9ebb355fa6b3df1d6b330436e0b885fb49594c41721398"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.23"
   flutter_qjs:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
       url: https://github.com/wgh136/webdav_client
       ref: 285f87f15bccd2d5d5ff443761348c6ee47b98d1
   battery_plus: ^6.2.0
+  file_picker: ^8.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
改进：优化导入函数逻辑
改进：漫画现在将选择自然序的第一个合法文件作为封面
新增：允许用户决定是否将漫画复制到本地目录（IOS、MacOS端未测试）
新增：删除无效的本地收藏项目


问题：导入/删除的漫画项目较多时，导入界面会假死


**关于安卓端的文件访问：**
众所周知，安卓的文件访问在安卓10之后有非常大的改进，其中，安卓10的限制最为严格。
为了能够在安卓10及以上正确访问外部存储，引入了`android:requestLegacyExternalStorage="true"`。
该标签实际只作用于安卓10，因为自安卓11起，由于该标签分区存储强制启用而被忽略