### PR TITLE
reader: fix start/end flipping

### DIFF
--- a/lib/pages/reader/reader.dart
+++ b/lib/pages/reader/reader.dart
@@ -244,7 +244,9 @@ abstract mixin class _ReaderLocation {
   bool toPage(int page) {
     if (_validatePage(page)) {
       if (page == this.page) {
-        return false;
+        if(!(chapter == 1 && page == 1) && !(chapter == maxChapter && page == maxPage)) {
+          return false;
+        }
       }
       this.page = page;
       update();


### PR DESCRIPTION
没有前后章节的情况 应当成为这个例外的例外，否则调 toPage 会直接返回 进入一个空页。
或者索性不进行这个判断。