### PR TITLE
add option to ignore certificate errors

### DIFF
--- a/assets/translation.json
+++ b/assets/translation.json
@@ -209,7 +209,8 @@
     "Update Comics Info": "更新漫画信息",
     "Create Folder": "新建文件夹",
     "Select an image on screen": "选择屏幕上的图片",
-    "Added @count comics to download queue.": "已添加 @count 本漫画到下载队列"
+    "Added @count comics to download queue.": "已添加 @count 本漫画到下载队列",
+    "Ignore Certificate Errors": "忽略证书错误"
   },
   "zh_TW": {
     "Home": "首頁",
@@ -421,6 +422,7 @@
     "Update Comics Info": "更新漫畫信息",
     "Create Folder": "新建文件夾",
     "Select an image on screen": "選擇屏幕上的圖片",
-    "Added @count comics to download queue.": "已添加 @count 本漫畫到下載隊列"
+    "Added @count comics to download queue.": "已添加 @count 本漫畫到下載隊列",
+    "Ignore Certificate Errors": "忽略證書錯誤"
   }
 }

--- a/lib/foundation/appdata.dart
+++ b/lib/foundation/appdata.dart
@@ -119,6 +119,7 @@ class _Settings with ChangeNotifier {
     'quickFavorite': null,
     'enableTurnPageByVolumeKey': true,
     'enableClockAndBatteryInfoInReader': true,
+    'ignoreCertificateErrors': false,
   };
 
   operator [](String key) {

--- a/lib/pages/settings/network.dart
+++ b/lib/pages/settings/network.dart
@@ -38,14 +38,11 @@ class _ProxySettingView extends StatefulWidget {
 
 class _ProxySettingViewState extends State<_ProxySettingView> {
   String type = '';
-
   String host = '';
-
   String port = '';
-
   String username = '';
-
   String password = '';
+  bool ignoreCertificateErrors = false;
 
   // USERNAME:PASSWORD@HOST:PORT
   String toProxyStr() {
@@ -103,6 +100,7 @@ class _ProxySettingViewState extends State<_ProxySettingView> {
   void initState() {
     var proxy = appdata.settings['proxy'];
     parseProxyString(proxy);
+    ignoreCertificateErrors = appdata.settings['ignoreCertificateErrors'] ?? false;
     super.initState();
   }
 
@@ -148,6 +146,17 @@ class _ProxySettingViewState extends State<_ProxySettingView> {
               },
             ),
             if (type == 'manual') buildManualProxy(),
+            SwitchListTile(
+              title: Text("Ignore Certificate Errors".tl),
+              value: ignoreCertificateErrors,
+              onChanged: (v) {
+                setState(() {
+                  ignoreCertificateErrors = v;
+                });
+                appdata.settings['ignoreCertificateErrors'] = ignoreCertificateErrors;
+                appdata.saveData();
+              },
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Adds a new setting to the app to allow users to ignore certificate errors. This may be useful for debugging purposes, for example when using a local proxy such as Burp Suite.