### PR TITLE
Setting `checkUpdateOnStart` to false by default

### DIFF
--- a/lib/foundation/appdata.dart
+++ b/lib/foundation/appdata.dart
@@ -113,7 +113,7 @@ class _Settings with ChangeNotifier {
     'cacheSize': 2048, // in MB
     'downloadThreads': 5,
     'enableLongPressToZoom': true,
-    'checkUpdateOnStart': true,
+    'checkUpdateOnStart': false,
     'limitImageWidth': true,
     'webdav': [], // empty means not configured
     'dataVersion': 0,


### PR DESCRIPTION
- https://gitlab.com/fdroid/fdroiddata/-/merge_requests/17644#note_2282972406

It should be disabled until users explicitly agreed.

You can leave auto update to installation sources, like F-Droid.