### PR TITLE
rustup default stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           distribution: 'oracle'
           java-version: '17'
+      - name: Setup Rust
+        run: |
+          rustup update
+          rustup default stable
       - run: flutter pub get
       - run: flutter build apk --release
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Rust released 1.84.0 recently, and got to be used in fdroidserver build because it is installed from `rustup-init.sh` every build. While at the same time, the included version in GitHub Runner [is still 1.83.0](https://github.com/actions/runner-images/blob/ubuntu24/20250105.1/images/ubuntu/Ubuntu2404-Readme.md#rust-tools), which caused a difference in librhttp.so between the two channels and effectively [failed the Reproducible Builds]( https://gitlab.com/fdroid/fdroiddata/-/merge_requests/18682/pipelines).

Actually I have tried to downgrade Rust to match GitHub Runner's, but no luck.

- https://gitlab.com/fdroid/fdroiddata/-/merge_requests/18701

Probably a quick fix is to let both sides use the stable version. Confirmed to work.