### PR TITLE
Fix ensure searchTarget is properly initialized for aggregatedSearch mode

### DIFF
--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -142,6 +142,8 @@ class _SearchPageState extends State<SearchPage> {
     var defaultSearchTarget = appdata.settings['defaultSearchTarget'];
     if (defaultSearchTarget == "_aggregated_") {
       aggregatedSearch = true;
+      searchTarget = ComicSource.all().where((e) => e.searchPageData != null)
+          .toList().first.key;
     } else if (defaultSearchTarget != null &&
         ComicSource.find(defaultSearchTarget) != null) {
       searchTarget = defaultSearchTarget;


### PR DESCRIPTION
Set searchTarget = defaultSearchTarget when aggregatedSearch is enabled, ensuring correct initialization and preventing missing suggestions on first input.

Without this fix, when opening the search page for the first time with aggregatedSearch enabled by default, entering an ID that matches a comic source does not trigger the "Open comic" suggestion. However, after toggling aggregatedSearch off and then back on, the same ID input correctly displays the suggestion.