### PR TITLE
pre-search: enable suggestions for EN

### DIFF
--- a/lib/utils/tags_translation.dart
+++ b/lib/utils/tags_translation.dart
@@ -15,9 +15,6 @@ extension TagsTranslation on String{
   static final Map<String, Map<String, String>> _data = {};
 
   static Future<void> readData() async{
-    if(App.locale.languageCode != "zh"){
-      return;
-    }
     var fileName = App.locale.countryCode == 'TW'
         ? "assets/tags_tw.json"
         : "assets/tags.json";


### PR DESCRIPTION
App 语言为英语时的搜索建议（无翻译）依然需要读取 tags 库。