### PR TITLE
Add AppImage build support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,45 @@ jobs:
           sudo rm -rf build/linux/arch/pkg
           sudo rm -rf build/linux/arch/src
           sudo rm -rf build/linux/arch/PKGBUILD
+      - name: Build AppImage
+        run: |
+          sudo apt-get install -y libfuse2
+          wget -O appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x appimagetool
+          
+          mkdir -p Venera.AppDir
+          cp -r build/linux/x64/release/bundle/* Venera.AppDir/
+          
+          cat > Venera.AppDir/venera.desktop << EOF
+          [Desktop Entry]
+          Name=Venera
+          Exec=venera
+          Icon=venera
+          Type=Application
+          Categories=Utility;
+          EOF
+          
+          cp assets/app_icon.png Venera.AppDir/venera.png
+          
+          cat > Venera.AppDir/AppRun << EOF
+          #!/bin/sh
+          HERE=\$(dirname \$(readlink -f "\${0}"))
+          export PATH="\${HERE}"/usr/bin/:"\${HERE}"/usr/sbin/:"\${HERE}"/usr/games/:"\${HERE}"/bin/:"\${HERE}"/sbin/:\${PATH}
+          export LD_LIBRARY_PATH="\${HERE}"/usr/lib/:\${LD_LIBRARY_PATH}
+          export XDG_DATA_DIRS="\${HERE}"/usr/share/:\${XDG_DATA_DIRS}
+          exec "\${HERE}"/venera "\$@"
+          EOF
+          chmod +x Venera.AppDir/AppRun
+          
+          APP_VERSION=$(grep "version:" pubspec.yaml | cut -d':' -f2 | tr -d ' ')
+          ./appimagetool Venera.AppDir Venera-${APP_VERSION}-x86_64.AppImage
+          
+          mkdir -p build/linux/appimage
+          mv Venera-${APP_VERSION}-x86_64.AppImage build/linux/appimage/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: appimage_build
+          path: build/linux/appimage
       - uses: actions/upload-artifact@v4
         with:
           name: deb_build
@@ -170,6 +209,45 @@ jobs:
           sudo apt-get install -y ninja-build libgtk-3-dev webkit2gtk-4.1
           dart pub global activate flutter_to_debian
       - run: python3 debian/build.py arm64
+      - name: Build AppImage
+        run: |
+          sudo apt-get install -y libfuse2
+          wget -O appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-aarch64.AppImage"
+          chmod +x appimagetool
+          
+          mkdir -p Venera.AppDir
+          cp -r build/linux/arm64/release/bundle/* Venera.AppDir/
+          
+          cat > Venera.AppDir/venera.desktop << EOF
+          [Desktop Entry]
+          Name=Venera
+          Exec=venera
+          Icon=venera
+          Type=Application
+          Categories=Utility;
+          EOF
+          
+          cp assets/app_icon.png Venera.AppDir/venera.png
+          
+          cat > Venera.AppDir/AppRun << EOF
+          #!/bin/sh
+          HERE=\$(dirname \$(readlink -f "\${0}"))
+          export PATH="\${HERE}"/usr/bin/:"\${HERE}"/usr/sbin/:"\${HERE}"/usr/games/:"\${HERE}"/bin/:"\${HERE}"/sbin/:\${PATH}
+          export LD_LIBRARY_PATH="\${HERE}"/usr/lib/:\${LD_LIBRARY_PATH}
+          export XDG_DATA_DIRS="\${HERE}"/usr/share/:\${XDG_DATA_DIRS}
+          exec "\${HERE}"/venera "\$@"
+          EOF
+          chmod +x Venera.AppDir/AppRun
+          
+          APP_VERSION=$(grep "version:" pubspec.yaml | cut -d':' -f2 | tr -d ' ')
+          ./appimagetool Venera.AppDir Venera-${APP_VERSION}-aarch64.AppImage
+          
+          mkdir -p build/linux/appimage
+          mv Venera-${APP_VERSION}-aarch64.AppImage build/linux/appimage/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: appimage_arm64_build
+          path: build/linux/appimage
       - uses: actions/upload-artifact@v4
         with:
           name: deb_arm64_build
@@ -208,6 +286,14 @@ jobs:
         with:
           name: deb_arm64_build
           path: outputs
+      - uses: actions/download-artifact@v4
+        with:
+          name: appimage_build
+          path: outputs
+      - uses: actions/download-artifact@v4
+        with:
+          name: appimage_arm64_build
+          path: outputs
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
@@ -219,5 +305,6 @@ jobs:
             outputs/*.exe
             outputs/*.deb
             outputs/*.zst
+            outputs/*.AppImage
         env:
           GITHUB_TOKEN: ${{ secrets.ACTION_GITHUB_TOKEN }}


### PR DESCRIPTION
Verified on steamdeck x86_64 AppImage, webkit2gtk(webkit2gtk-4.1) is necessary installed before run it
related #209 