### PR TITLE
Fix history of maxPage when maxPage in reader is 1

### DIFF
--- a/lib/pages/reader/reader.dart
+++ b/lib/pages/reader/reader.dart
@@ -240,9 +240,7 @@ class _ReaderState extends State<Reader>
         /// Record the first image of the page
         history!.page = (page - 1) * imagesPerPage + 1;
       }
-      if (maxPage > 1) {
-        history!.maxPage = images?.length ?? 1;
-      }
+      history!.maxPage = images?.length ?? 1;
       if (widget.chapters?.isGrouped ?? false) {
         int g = 0;
         int c = chapter;


### PR DESCRIPTION
Due to the change of page and maxPage before, the history of maxPage should be real maxPage in any case.
If not, when maxPage in reader is 1, the maxPage in history will be none or the last ep's real maxPage.