### PR TITLE
Fix abnormal history recording when not flipping pages. Close #392

### DIFF
--- a/lib/pages/reader/images.dart
+++ b/lib/pages/reader/images.dart
@@ -40,6 +40,9 @@ class _ReaderImagesState extends State<_ReaderImages> {
           reader.images = images;
           reader.isLoading = false;
           inProgress = false;
+          Future.microtask(() {
+            reader.updateHistory();
+          });
         });
       } catch (e) {
         setState(() {
@@ -65,6 +68,9 @@ class _ReaderImagesState extends State<_ReaderImages> {
           reader.images = res.data;
           reader.isLoading = false;
           inProgress = false;
+          Future.microtask(() {
+            reader.updateHistory();
+          });
         });
       }
     }

--- a/lib/pages/reader/reader.dart
+++ b/lib/pages/reader/reader.dart
@@ -164,9 +164,6 @@ class _ReaderState extends State<Reader>
     }
     mode = ReaderMode.fromKey(appdata.settings['readerMode']);
     history = widget.history;
-    Future.microtask(() {
-      updateHistory();
-    });
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
     if (appdata.settings['enableTurnPageByVolumeKey']) {
       handleVolumeEvent();


### PR DESCRIPTION
images is null when initState, so maxPage in updateHistory is 1 by default.