### PR TITLE
Only add closeListener when app is desktop

### DIFF
--- a/lib/utils/data_sync.dart
+++ b/lib/utils/data_sync.dart
@@ -22,10 +22,12 @@ class DataSync with ChangeNotifier {
     }
     LocalFavoritesManager().addListener(onDataChanged);
     ComicSourceManager().addListener(onDataChanged);
-    Future.delayed(const Duration(seconds: 1), () {
-      var controller = WindowFrame.of(App.rootContext);
-      controller.addCloseListener(_handleWindowClose);
-    });
+    if (App.isDesktop) {
+      Future.delayed(const Duration(seconds: 1), () {
+        var controller = WindowFrame.of(App.rootContext);
+        controller.addCloseListener(_handleWindowClose);
+      });
+    }
   }
 
   void onDataChanged() {


### PR DESCRIPTION
```
Null check operator used on a null value
#0      WindowFrame.of (package:venera/components/window_frame.dart:50)
#1      new DataSync._.<anonymous closure> (package:venera/utils/data_sync.dart:26)
#2      new Future.delayed.<anonymous closure> (dart:async/future.dart:419)
#3      _rootRun (dart:async/zone.dart:1517)
#4      _CustomZone.run (dart:async/zone.dart:1422)
#5      _CustomZone.runGuarded (dart:async/zone.dart:1321)
#6      _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1362)
#7      _rootRun (dart:async/zone.dart:1525)
#8      _CustomZone.run (dart:async/zone.dart:1422)
#9      _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:1345)
#10     TickerFuture.whenCompleteOrCancel.thunk (package:flutter/src/scheduler/ticker.dart:450)
#11     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:410)
#12     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:441)
#13     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193)
```