### PR TITLE
fix padding check error on ios

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -248,7 +248,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                 MediaQuery.of(context).viewPadding.top <= 0 ||
                 MediaQuery.of(context).viewPadding.top > 50;
 
-            if (isPaddingCheckError) {
+            if (isPaddingCheckError && !Platform.isIOS) {
               widget = MediaQuery(
                   data: MediaQuery.of(context).copyWith(
                     viewPadding: const EdgeInsets.only(


### PR DESCRIPTION
In version 1.5.0, an error in calculating the navbar safe area on iOS systems was introduced. As shown in the following figure.
<img width="417" height="898" alt="Snipaste_2025-09-04_19-59-14" src="https://github.com/user-attachments/assets/6407fdfc-f9ff-4e7d-894c-b450ddc968bd" />

So add an iOS system judgment exclusion for the applicable conditions of isPaddingCheckError. The fix is shown in the following figure.
<img width="417" height="898" alt="Snipaste_2025-09-04_19-58-44" src="https://github.com/user-attachments/assets/9e3cd920-62f5-4ef5-ade0-67812d6af57e" />
