### PR TITLE
fix "no space left"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,8 @@ jobs:
   Build_Android:
     runs-on: ubuntu-22.04
     steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
to increase disk space in GitHub Actions, you can free up space by deleting unnecessary software