### PR TITLE
Enhance Cloudflare challenge detection logic

### DIFF
--- a/lib/network/cloudflare.dart
+++ b/lib/network/cloudflare.dart
@@ -128,10 +128,15 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
         var head =
             await controller.evaluateJavascript("document.head.innerHTML") ??
                 "";
+        var body =
+            await controller.evaluateJavascript("document.body.innerHTML") ??
+                "";
         Log.info("Cloudflare", "Checking head: $head");
         var isChallenging = head.contains('#challenge-success-text') ||
             head.contains("#challenge-error-text") ||
-            head.contains("#challenge-form");
+            head.contains("#challenge-form") ||
+            body.contains("challenge-platform") ||
+            body.contains("window._cf_chl_opt");
         if (!isChallenging) {
           Log.info(
             "Cloudflare",
@@ -159,10 +164,14 @@ void passCloudflare(CloudflareException e, void Function() onFinished) async {
     void check(InAppWebViewController controller) async {
       var head = await controller.evaluateJavascript(
           source: "document.head.innerHTML") as String;
+      var body = await controller.evaluateJavascript(
+          source: "document.body.innerHTML") as String;
       Log.info("Cloudflare", "Checking head: $head");
       var isChallenging = head.contains('#challenge-success-text') ||
           head.contains("#challenge-error-text") ||
-          head.contains("#challenge-form");
+          head.contains("#challenge-form") ||
+          body.contains("challenge-platform") ||
+          body.contains("window._cf_chl_opt");
       if (!isChallenging) {
         Log.info(
           "Cloudflare",


### PR DESCRIPTION
添加了验证body内的，防止一些网站的漏判。自定义源的时候，像嗨皮漫画的验证识别不了。[嗨皮漫画](https://m.happymh.com/sssearch)，需要翻墙