### PR TITLE
Save file name: {comic}_EP{chapter}_P{page}.{ext} to avoid conflict.

### DIFF
--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -628,8 +628,10 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     }
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
+    // Save file name: ComicName_EP{chapter}_P{page}.{ext} to avoid conflict.
+    // The chapter index of different group is continuous, so we use chapter number is enough.
     var filename =
-        "${context.reader.widget.name}_${imageIndex + 1}${fileType.ext}";
+        "${context.reader.widget.name}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
     saveFile(data: data, filename: filename);
   }
 
@@ -641,7 +643,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
     var filename =
-        "${context.reader.widget.name}_${imageIndex + 1}${fileType.ext}";
+        "${context.reader.widget.name}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
     Share.shareFile(data: data, filename: filename, mime: fileType.mime);
   }
 


### PR DESCRIPTION
The chapter index of different group is continuous, so we use chapter number is enough.