### PR TITLE
fix: disable image resizing to prevent blurry images

### DIFF
--- a/lib/foundation/image_provider/reader_image.dart
+++ b/lib/foundation/image_provider/reader_image.dart
@@ -122,5 +122,5 @@ class ReaderImageProvider
   String get key => "$imageKey@$sourceKey@$cid@$eid";
 
   @override
-  bool get enableResize => true;
+  bool get enableResize => false;
 }


### PR DESCRIPTION
### What does this PR do?
This PR fixes a severe image quality issue (blurry images) in the comic reader.

### Why is this necessary?
In `lib/foundation/image_provider/reader_image.dart`, `enableResize` was set to `true`. When rendering long/large comic images, the Flutter engine downsampled the raw images based on logical pixels (ignoring `devicePixelRatio`). This caused high-resolution original network images to be aggressively compressed into low-resolution textures, resulting in severe blurring compared to other readers.

By changing `enableResize => false`, the engine retains the original image pixels, restoring the image quality to exactly match the original source without quality loss.

---


### 该 PR 做了什么？
本 PR 修复了漫画阅读器中图片模糊的严重画质问题。

### 为什么需要这样修改？
在 `lib/foundation/image_provider/reader_image.dart` 文件中，`enableResize` 被设置为 `true`。
在渲染长图/大尺寸漫画图片时，Flutter 引擎会根据逻辑像素对原始图片进行下采样（忽略 `devicePixelRatio`），
导致原本高清的网络图片被过度压缩成低分辨率纹理，相比其他阅读器出现严重模糊。

将 `enableResize => false` 后，引擎会保留原始图片像素，使图片画质恢复到与原图完全一致，无画质损失。