### PR TITLE
feat: Support dynamic settings for comic sources

### DIFF
--- a/lib/foundation/comic_source/comic_source.dart
+++ b/lib/foundation/comic_source/comic_source.dart
@@ -242,6 +242,39 @@ class ComicSource {
     return !res.error;
   }
 
+  /// Get settings dynamically from JavaScript source.
+  /// This allows sources to use getters for dynamic settings that can change at runtime.
+  Map<String, Map<String, dynamic>>? getSettingsDynamic() {
+    try {
+      var value = JsEngine().runCode("ComicSource.sources.$key.settings");
+      if (value is Map) {
+        var newMap = <String, Map<String, dynamic>>{};
+        for (var e in value.entries) {
+          if (e.key is! String) {
+            continue;
+          }
+          var v = <String, dynamic>{};
+          for (var e2 in e.value.entries) {
+            if (e2.key is! String) {
+              continue;
+            }
+            var v2 = e2.value;
+            if (v2 is JSInvokable) {
+              v2 = JSAutoFreeFunction(v2);
+            }
+            v[e2.key] = v2;
+          }
+          newMap[e.key] = v;
+        }
+        return newMap;
+      }
+      return null;
+    } catch (e) {
+      Log.error("ComicSource", "Failed to get dynamic settings: $e");
+      return settings;
+    }
+  }
+
   ComicSource(
     this.name,
     this.key,

--- a/lib/pages/comic_source_page.dart
+++ b/lib/pages/comic_source_page.dart
@@ -897,12 +897,15 @@ class _SliverComicSourceState extends State<_SliverComicSource> {
   }
 
   Iterable<Widget> buildSourceSettings() sync* {
-    if (source.settings == null) {
+    // Try to get dynamic settings first (for getters), fall back to cached settings
+    var settingsMap = source.getSettingsDynamic() ?? source.settings;
+    
+    if (settingsMap == null) {
       return;
     } else if (source.data['settings'] == null) {
       source.data['settings'] = {};
     }
-    for (var item in source.settings!.entries) {
+    for (var item in settingsMap.entries) {
       var key = item.key;
       String type = item.value['type'];
       try {


### PR DESCRIPTION
Allow comic sources to define settings as a getter that returns dynamic values. This enables sources to update their options at runtime (e.g., dynamically generated domain lists) without requiring source file modification.

Changes:
- Add getSettingsDynamic() method to ComicSource class to fetch settings from JavaScript on each access instead of using cached values
- Modify buildSourceSettings() in ComicSourcePage to use getSettingsDynamic() for fresh settings data
- Fall back to cached settings if dynamic retrieval fails

This fixes the limitation where settings defined as JavaScript getters would only be evaluated once at source load time, preventing dynamic updates.